### PR TITLE
Fix a deprecation warning from rspec.

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -15,7 +15,7 @@ describe 'openconnect' do
             :pass => 'mekmitasdigoat',
           }}
 
-          it { should include_class('openconnect::params') }
+          it { should contain_class('openconnect::params') }
 
           it { should contain_class('openconnect::install') }
           it { should contain_class('openconnect::config') }


### PR DESCRIPTION
```
DEPRECATION: include_class is deprecated. Use contain_class instead.
Called from
/home/bob/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/rspec-puppet-1.0.1/lib/rspec-puppet/matchers/include_class.rb:7:in
`block (2 levels) in <module:ManifestMatchers>'.
```
