### PR TITLE
Disable hasrestart for service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,11 +6,13 @@
 class openconnect::service {
   include openconnect::params
 
+  # Disable `hasrestart` because otherwise upstart won't pick up
+  # option/argument changes to the init file.
   service { $openconnect::params::service_name:
     ensure     => running,
     enable     => true,
     hasstatus  => true,
-    hasrestart => true,
+    hasrestart => false,
     provider   => 'upstart',
   }
 }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -6,7 +6,18 @@ describe 'openconnect::service' do
       :osfamily => 'Debian',
     }}
 
-    it { should contain_service('openconnect') }
+    it 'should manage service' do
+      should contain_service('openconnect').with({
+        :ensure => 'running',
+        :enable => 'true',
+      })
+    end
+
+    it 'should stop+start to pick up changes' do
+      should contain_service('openconnect').with({
+        :hasrestart => false,
+      })
+    end
   end
 end
 


### PR DESCRIPTION
Disable the `hasrestart` param for the service so that Puppet calls `stop`
and then `start` in order to pick up changes to the job configuration such
as different arguments (such as endpoint or password changes).

From: http://upstart.ubuntu.com/cookbook/#restart

> Note that restart is not the same as running stop followed by start since
> the restart command will retain the original job configuration whereas
> stopping the job and restarting it will load the latest job configuration
> from disk.
