### PR TITLE
Send logs to syslog

### DIFF
--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -24,6 +24,10 @@ describe 'openconnect' do
       )
     end
 
+    it 'should enable syslog' do
+      should contain_file(upstart_file).with_content(/\s+--syslog\s+/)
+    end
+
     it 'should set user' do
       should contain_file(upstart_file).with_content(
         /^\s*--user janesmith \\$/

--- a/templates/etc/init/openconnect.conf.erb
+++ b/templates/etc/init/openconnect.conf.erb
@@ -13,6 +13,7 @@ export DNS_UPDATE
 
 exec cat /etc/openconnect/network.passwd | openconnect \
   <%= @url -%> \
+  --syslog \
   --no-dtls \
   --script /etc/vpnc/vpnc-script \
 <% unless @cacerts.empty? -%>


### PR DESCRIPTION
Because the logs that upstart creates from STDIN don't contain any
timestamps, which makes debugging pretty difficult. By logging to syslog we
get these for free. This is supported by both versions:
- 3.15-0ubuntu2 on Precise
- 2.22-1 on Lucid

This will allow Performance Platform to use this module instead of a fork
which uses `gawk` to add timestamps:
- alphagov/pp-puppet@dbac53139b9c38cd218a0ba6de049012b096c16a
- alphagov/pp-puppet@ce7cb1a02bdd5793c5ad3ed4ffc70315ad539909

Depends on #3 to pick up argument changes.

---

/cc @robyoung @tombooth
