### PR TITLE
Remove the deprecated Modulefile and replace with metadata.json

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,9 +1,0 @@
-name          'gdsoperations-openconnect'
-version       '1.0.0'
-source        'https://github.com/gds-operations/puppet-openconnect/'
-author        'Government Digital Service'
-license       'MIT'
-summary       'Cisco OpenConnect VPN client'
-project_page  'https://github.com/gds-operations/puppet-openconnect/'
-
-dependency 'puppetlabs/stdlib', '>= 3.0.0'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,24 @@
+{
+  "name":         "gdsoperations-openconnect",
+  "version":      "1.0.0",
+  "author":       "Government Digital Service",
+  "license":      "MIT",
+  "summary":      "Cisco OpenConnect VPN client",
+  "source":       "https://github.com/gds-operations/puppet-openconnect",
+  "project_page": "https://github.com/gds-operations/puppet-openconnect",
+  "issues_url":   "https://github.com/gds-operations/puppet-openconnect/issues",
+  "tags":         ["networking", "cisco", "vpn"],
+  "operatingsystem_support": [
+    {
+    "operatingsystem": "Ubuntu",
+    "operatingsystemrelease": ["12.04", "14.04"]
+    },
+    {
+    "operatingsystem": "Debian",
+    "operatingsystemrelease": ["7"]
+    }
+  ],
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.0.0 <5.0.0" }
+  ]
+}


### PR DESCRIPTION
Puppetforge now uses metadata.json. Moving to it means we'll get display
more relevant information on the forge pages and search results.

And gives us a higher score of course.