### PR TITLE
Add support for connecting via a proxy

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@ class openconnect::config {
   $cacerts    = $::openconnect::cacerts
   $servercert = $::openconnect::servercert
   $upstart    = $::openconnect::upstart
+  $proxy      = $::openconnect::proxy
 
   validate_string($url, $user, $pass, $cacerts, $servercert)
   validate_bool($dnsupdate)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,10 @@
 #   SHA1 fingerprint of trusted server's SSL certificate.
 #   Default: ''
 #
+# [*proxy*]
+#   The proxy to use to connect to the VPN
+#   Default: ''
+#
 class openconnect(
   $url,
   $user,
@@ -33,6 +37,7 @@ class openconnect(
   $cacerts = '',
   $servercert = '',
   $authgroup = undef,
+  $proxy = '',
 ) inherits openconnect::params {
 
   anchor { 'openconnect::begin': } ->

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -93,6 +93,18 @@ EOS
     end
   end
 
+  context 'proxy set' do
+    let(:params) { default_params.merge({
+      :proxy => 'http://localhost:8080',
+    })}
+
+    it 'should set the proxy option' do
+      should contain_file(upstart_file).with_content(
+        /^\s*--proxy="http:\/\/localhost:8080" \\$/
+      )
+    end
+  end
+
   context 'validate params' do
     %w{url user pass cacerts servercert}.each do |param|
       describe param do

--- a/templates/etc/init.d/openconnect.erb
+++ b/templates/etc/init.d/openconnect.erb
@@ -45,6 +45,9 @@ start ()
         <% unless @servercert.empty? -%>
         --servercert <%= @servercert -%> \
         <% end -%>
+        <% unless @proxy.empty? -%>
+        --proxy="<%= @proxy %>" \
+        <% end -%>
         --user <%= @user -%> \
         --passwd-on-stdin 
 

--- a/templates/etc/init/openconnect.conf.erb
+++ b/templates/etc/init/openconnect.conf.erb
@@ -25,5 +25,8 @@ exec cat /etc/openconnect/network.passwd | openconnect \
 <% unless @servercert.empty? -%>
   --servercert <%= @servercert -%> \
 <% end -%>
+<% unless @proxy.empty? -%>
+  --proxy="<%= @proxy %>" \
+<% end -%>
   --user <%= @user -%> \
   --passwd-on-stdin


### PR DESCRIPTION
The openconnect client has support for connecting using a proxy, so we
add support here for the CLI flag which enables this.