### PR TITLE
Fix vpnc package version

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,4 +8,10 @@ class openconnect::install {
   package { $openconnect::params::package_name:
     ensure => $::openconnect::version,
   }
+
+  if ! empty($openconnect::params::additional_packages) {
+    package { $openconnect::params::additional_packages:
+      ensure => present,
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,14 +6,16 @@
 class openconnect::params {
   case $::osfamily {
     'Debian': {
-      $package_name = ['vpnc', 'openconnect']
-      $service_name = 'openconnect'
-      $upstart      = true
+      $package_name        = 'openconnect'
+      $additional_packages = ['vpnc']
+      $service_name        = 'openconnect'
+      $upstart             = true
     }
     'RedHat': {
-      $package_name = ['openconnect']
-      $service_name = 'openconnect'
-      $upstart      = false
+      $package_name        = 'openconnect'
+      $additional_packages = []
+      $service_name        = 'openconnect'
+      $upstart             = false
     }
     default: {
       fail("${::operatingsystem} not supported")


### PR DESCRIPTION
On Debian based distributions the vpnc package version is set by the openconnect version parameter, which causes an error
when we try to pass a specific Openconnect version in the parameter.

We fix this bug by applying the version parameter only to the openconnect package.