### PR TITLE
Add ensure parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,17 +11,24 @@ class openconnect::config {
   $servercert = $::openconnect::servercert
   $upstart    = $::openconnect::upstart
   $proxy      = $::openconnect::proxy
+  $ensure     = $::openconnect::ensure
 
   validate_string($url, $user, $pass, $cacerts, $servercert)
   validate_bool($dnsupdate)
 
+  if $ensure == 'present' {
+    $ensure_dir = 'directory'
+  } else {
+    $ensure_dir = $ensure
+  }
+
   file { '/etc/openconnect':
-    ensure => directory,
+    ensure => $ensure_dir,
     mode   => '0700',
   }
 
   file { '/etc/openconnect/network.passwd':
-    ensure  => present,
+    ensure  => $ensure,
     mode    => '0600',
     content => $pass,
   }
@@ -36,13 +43,13 @@ class openconnect::config {
   }
   if $upstart {
     file { '/etc/init/openconnect.conf':
-      ensure  => present,
+      ensure  => $ensure,
       mode    => '0600',
       content => template('openconnect/etc/init/openconnect.conf.erb'),
     }
   } else {
     file { '/etc/init.d/openconnect':
-      ensure  => present,
+      ensure  => $ensure,
       mode    => '0700',
       content => template('openconnect/etc/init.d/openconnect.erb'),
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,7 @@ class openconnect(
   $authgroup = undef,
   $proxy = '',
   $version = 'present',
+  $ensure = 'present',
 ) inherits openconnect::params {
 
   anchor { 'openconnect::begin': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,13 +5,21 @@
 class openconnect::install {
   include openconnect::params
 
-  package { $openconnect::params::package_name:
-    ensure => $::openconnect::version,
+  $ensure = $openconnect::ensure
+
+  if $ensure == 'present' {
+    package { $openconnect::params::package_name:
+      ensure => $::openconnect::version,
+    }
+  } else {
+    package { $openconnect::params::package_name:
+      ensure => $ensure,
+    }
   }
 
   if ! empty($openconnect::params::additional_packages) {
     package { $openconnect::params::additional_packages:
-      ensure => present,
+      ensure => $ensure,
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,11 +6,17 @@
 class openconnect::service {
   include openconnect::params
 
+  if $openconnect::ensure == 'absent' {
+    $ensure = 'stopped'
+  } else {
+    $ensure = 'running'
+  }
+
   # Disable `hasrestart` because otherwise upstart won't pick up
   # option/argument changes to the init file.
   if $openconnect::params::upstart {
     service { $openconnect::params::service_name:
-      ensure     => running,
+      ensure     => $ensure,
       enable     => true,
       hasstatus  => true,
       hasrestart => false,
@@ -18,7 +24,7 @@ class openconnect::service {
     }
   } else {
     service { $openconnect::params::service_name:
-      ensure     => running,
+      ensure     => $ensure,
       enable     => true,
       hasstatus  => true,
       hasrestart => true,


### PR DESCRIPTION
Add an ensure parameter, to allow setting to 'absent' and removing all resources when they are no longer required.

It is a danger to have this configuration hanging round as it allows logging into a private VPN.